### PR TITLE
feat: allow rust hooks to specify crate features

### DIFF
--- a/tests/languages/rust_test.py
+++ b/tests/languages/rust_test.py
@@ -44,13 +44,19 @@ def _make_hello_world(tmp_path):
     src_dir.joinpath('main.rs').write_text(
         'fn main() {\n'
         '    println!("Hello, world!");\n'
+        '    if cfg!(feature = "foo") {\n'
+        '        println!("With feature foo");\n'
+        '    }\n'
         '}\n',
     )
     tmp_path.joinpath('Cargo.toml').write_text(
         '[package]\n'
         'name = "hello_world"\n'
         'version = "0.1.0"\n'
-        'edition = "2021"\n',
+        'edition = "2021"\n'
+        '\n'
+        '[features]\n'
+        'foo = []\n',
     )
 
 
@@ -113,3 +119,12 @@ def test_run_lib_additional_dependencies(tmp_path):
     assert bin_dir.is_dir()
     assert not bin_dir.joinpath('shellharden').exists()
     assert not bin_dir.joinpath('shellharden.exe').exists()
+
+
+def test_run_features_additional_dependencies(tmp_path):
+    _make_hello_world(tmp_path)
+
+    deps = ('shellharden:4.2.0', 'git-version')
+    features = ('--feature=foo',)
+    ret = run_language(tmp_path, rust, 'hello_world', deps=deps + features)
+    assert ret == (0, b'Hello, world!\nWith feature foo\n')


### PR DESCRIPTION
Now the rust hooks can use the parameter `additional_dependencies` to receive build-time features for the crate.

The features must start with the string "--feature=" following the name of the feature; e.g. "--feature=full".

Fixes #3230